### PR TITLE
Allow setting of foundationInitialAddress via environment variable

### DIFF
--- a/btrust-config.js
+++ b/btrust-config.js
@@ -3,7 +3,7 @@ module.exports = {
   decimals: 18,
   networks: {
     development: {
-      foundationInitialAddress: '0xc1638e6d00f2c4adc0ec8bd8d4108e1c00c53ae6'
+      foundationInitialAddress: process.env.FOUNDATION_ADDRESS || '0xc1638e6d00f2c4adc0ec8bd8d4108e1c00c53ae6'
     },
     ropsten: {
       foundationInitialAddress: '0xc2e0754cdeb7e6d0f80251e9c1a08bc2c2ede17a'


### PR DESCRIPTION
So that it's easier to setup integration on localhost, allow passing foundation address as environment variable. 